### PR TITLE
Update Microsoft.CodeAnalysis.CSharp.Workspace dependency to 3.8.0

### DIFF
--- a/Umbraco.Code.Tests/Umbraco.Code.Tests.csproj
+++ b/Umbraco.Code.Tests/Umbraco.Code.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />

--- a/Umbraco.Code/Umbraco.Code.csproj
+++ b/Umbraco.Code/Umbraco.Code.csproj
@@ -5,7 +5,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>Umbraco HQ</Authors>
     <Company>Umbraco</Company>
     <PackageProjectUrl>https://github.com/umbraco/Umbraco-Code</PackageProjectUrl>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In the CMS we have a dependency to Microsoft.CodeAnalysis.CSharp >= 3.8.0, in infrastructure project which in turn means we have that dependency in all projects with a reference to infrastructure, which is most of them.

Unfortunately the Microsoft.CodeAnalysis.CSharp.Workspaces dependency we use here have a very strict dependency to Microsoft.CodeAnalysis.CSharp, where the version has to be the same as workspaces (see dependencies section here https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp.Workspaces/3.8.0)

This means that we can't install Umbraco.Code before Microsoft.CodeAnalysis.CSharp.Workspaces is updated to v 3.8.0