### PR TITLE
Update dependencies and bump to 3.0.0-beta

### DIFF
--- a/Umbraco.Code.Tests/Umbraco.Code.Tests.csproj
+++ b/Umbraco.Code.Tests/Umbraco.Code.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Umbraco.Code/Umbraco.Code.csproj
+++ b/Umbraco.Code/Umbraco.Code.csproj
@@ -13,12 +13,12 @@
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>2.4.0</Version>
+		<Version>3.0.0</Version>
 		<Description>Code-level tools for Umbraco</Description>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.14.0,4.999.999)" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[5.0.0,5.999.999)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Umbraco.Code/Umbraco.Code.csproj
+++ b/Umbraco.Code/Umbraco.Code.csproj
@@ -13,7 +13,7 @@
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>3.0.0</Version>
+		<Version>3.0.0-beta</Version>
 		<Description>Code-level tools for Umbraco</Description>
 	</PropertyGroup>
 


### PR DESCRIPTION
This will allow us to take a dependency on `Umbraco.Code` 3.0 in Umbraco CMS and allow upgrading of the `Microsoft.CodeAnalysis.*` dependencies within that project.